### PR TITLE
Add Python script for MLP regression

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # PROGRAMACION
+
+This repository provides examples for building a simple multilayer perceptron (MLP) regression model with PyTorch. You can run the code either as a Jupyter notebook or directly from a Python script.
+
+## Contents
+
+- `mlp_regression.ipynb` – step-by-step notebook that loads data, trains a small MLP, and visualizes the results.
+- `mlp_regression.py` – equivalent Python script you can execute from the command line.
+
+## Running
+
+Install the dependencies and execute the notebook or script:
+
+```bash
+pip install torch matplotlib scikit-learn pandas
+
+# run as script
+python mlp_regression.py
+```
+
+[Open the notebook in Colab](https://colab.research.google.com/github/your-user/your-repo/blob/main/mlp_regression.ipynb)
+
+## License
+
+This project is released under the [MIT License](LICENSE).
+

--- a/mlp_regression.ipynb
+++ b/mlp_regression.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MLP Regression Example\n",
+    "This notebook shows how to train a simple multilayer perceptron with PyTorch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "import torch\n",
+    "from torch.utils.data import TensorDataset, DataLoader\n",
+    "\n",
+    "# synthetic data\n",
+    "X = np.array([258.0, 270.0, 294.0, 320.0, 342.0, 368.0, 396.0, 446.0, 480.0, 586.0])[:, None]\n",
+    "y = np.array([236.4, 234.4, 252.8, 298.6, 314.2, 342.2, 360.8, 368.0, 391.2, 390.8])\n",
+    "\n",
+    "plt.scatter(X, y)\n",
+    "plt.xlabel(\"X\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lr = LinearRegression()\n",
+    "lr.fit(X, y)\n",
+    "\n",
+    "X_range = np.arange(250, 600, 10)[:, None]\n",
+    "y_linear = lr.predict(X_range)\n",
+    "\n",
+    "plt.scatter(X, y, label=\"Datos\")\n",
+    "plt.plot(X_range, y_linear, label=\"Regresión lineal\", linestyle=\"--\", color=\"orange\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# normalize data\n",
+    "x_mean, x_std = X.mean(), X.std()\n",
+    "y_mean, y_std = y.mean(), y.std()\n",
+    "X_norm = (X - x_mean) / x_std\n",
+    "y_norm = (y - y_mean) / y_std\n",
+    "\n",
+    "tensor_X = torch.tensor(X_norm, dtype=torch.float32)\n",
+    "tensor_y = torch.tensor(y_norm, dtype=torch.float32)\n",
+    "dataset = TensorDataset(tensor_X, tensor_y)\n",
+    "dataloader = DataLoader(dataset)\n",
+    "\n",
+    "class MLP(torch.nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.layers = torch.nn.Sequential(\n",
+    "            torch.nn.Linear(1, 1),\n",
+    "            torch.nn.ReLU(),\n",
+    "            torch.nn.Linear(1, 1)\n",
+    "        )\n",
+    "    def forward(self, x):\n",
+    "        return self.layers(x)\n",
+    "\n",
+    "model = MLP()\n",
+    "loss_fn = torch.nn.MSELoss()\n",
+    "optimizer = torch.optim.SGD(model.parameters(), lr=0.1)\n",
+    "\n",
+    "loss_history = []\n",
+    "for epoch in range(200):\n",
+    "    for f, t in dataloader:\n",
+    "        out = model(f)\n",
+    "        loss = loss_fn(out.squeeze(), t)\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "    loss_history.append(loss.item())\n",
+    "\n",
+    "plt.plot(loss_history)\n",
+    "plt.xlabel(\"epoch\")\n",
+    "plt.ylabel(\"loss\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.eval()\n",
+    "X_range_norm = (X_range - x_mean) / x_std\n",
+    "X_range_norm = torch.tensor(X_range_norm, dtype=torch.float32)\n",
+    "y_mlp_norm = model(X_range_norm).detach().numpy().astype(float)\n",
+    "y_mlp = y_mlp_norm * y_std + y_mean\n",
+    "\n",
+    "plt.scatter(X, y, label=\"Datos\")\n",
+    "plt.plot(X_range, y_linear, label=\"Regresión lineal\", linestyle=\"--\", color=\"green\")\n",
+    "plt.plot(X_range, y_mlp, label=\"MLP\", color=\"orange\")\n",
+    "plt.xlabel(\"X\")\n",
+    "plt.ylabel(\"y\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mlp_regression.py
+++ b/mlp_regression.py
@@ -1,0 +1,85 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.linear_model import LinearRegression
+import torch
+from torch.utils.data import TensorDataset, DataLoader
+
+# synthetic data
+X = np.array([
+    258.0, 270.0, 294.0, 320.0, 342.0,
+    368.0, 396.0, 446.0, 480.0, 586.0
+])[:, None]
+
+y = np.array([
+    236.4, 234.4, 252.8, 298.6, 314.2,
+    342.2, 360.8, 368.0, 391.2, 390.8
+])
+
+# simple linear regression for comparison
+lr = LinearRegression()
+lr.fit(X, y)
+X_range = np.arange(250, 600, 10)[:, None]
+y_linear = lr.predict(X_range)
+
+# normalize data for the MLP
+x_mean, x_std = X.mean(), X.std()
+y_mean, y_std = y.mean(), y.std()
+X_norm = (X - x_mean) / x_std
+y_norm = (y - y_mean) / y_std
+
+# dataset and dataloader
+features = torch.tensor(X_norm, dtype=torch.float32)
+targets = torch.tensor(y_norm, dtype=torch.float32)
+dataset = TensorDataset(features, targets)
+dataloader = DataLoader(dataset)
+
+class MLP(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layers = torch.nn.Sequential(
+            torch.nn.Linear(1, 1),
+            torch.nn.ReLU(),
+            torch.nn.Linear(1, 1)
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+model = MLP()
+loss_fn = torch.nn.MSELoss()
+optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+loss_history = []
+for epoch in range(200):
+    for f, t in dataloader:
+        out = model(f)
+        loss = loss_fn(out.squeeze(), t)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+    loss_history.append(loss.item())
+
+# evaluate
+model.eval()
+X_range_norm = (X_range - x_mean) / x_std
+X_range_norm = torch.tensor(X_range_norm, dtype=torch.float32)
+y_mlp_norm = model(X_range_norm).detach().numpy().astype(float)
+y_mlp = y_mlp_norm * y_std + y_mean
+
+# plot results
+plt.figure(figsize=(8, 4))
+plt.subplot(1, 2, 1)
+plt.plot(loss_history)
+plt.xlabel("epoch")
+plt.ylabel("loss")
+
+plt.subplot(1, 2, 2)
+plt.scatter(X, y, label="Datos")
+plt.plot(X_range, y_linear, label="Regresión lineal", linestyle="--", color="green")
+plt.plot(X_range, y_mlp, label="MLP", color="orange")
+plt.xlabel("X")
+plt.ylabel("y")
+plt.legend()
+
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
## Summary
- add `mlp_regression.py` to run the regression example without a notebook
- update README with script instructions

## Testing
- `python3 - <<'EOF'
import json
json.load(open('mlp_regression.ipynb'))
print('JSON ok')
EOF`
- `python3 mlp_regression.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844074ae25883269c627cf087d5bec9